### PR TITLE
Eliminerer warnings om at nabo ikke finnes

### DIFF
--- a/stages/download/wikidata/fylkenabo.sparql
+++ b/stages/download/wikidata/fylkenabo.sparql
@@ -1,4 +1,7 @@
 SELECT * WHERE {
-  ?item wdt:P31 wd:Q192299;
-    wdt:P47 ?shares_border_with.
+  ?item wdt:P31 wd:Q192299.
+  ?item p:P47 ?shares_border.
+  ?shares_border ps:P47 ?shares_border_with.
+ OPTIONAL{ ?shares_border pq:P580 ?start_time.}
+ OPTIONAL{ ?shares_border pq:P582 ?end_time.}
 }

--- a/stages/download/wikidata/kommunenabo.sparql
+++ b/stages/download/wikidata/kommunenabo.sparql
@@ -1,4 +1,7 @@
 SELECT * WHERE {
   ?item wdt:P31 wd:Q755707;
   wdt:P47 ?shares_border_with.
+  ?shares_border ps:P47 ?shares_border_with.
+  OPTIONAL{ ?shares_border pq:P580 ?start_time.}
+  OPTIONAL{ ?shares_border pq:P582 ?end_time.}
 }


### PR DESCRIPTION
- Laster start og sluttdato for objektet som det grenses til og filtrerer bort områder som ikke lenger eksisterer
- Unngår å vise advarsel for grenser til svenske län fordi de inngår uansett ikke i datasettet