### PR TITLE
Tweak release file contents

### DIFF
--- a/.github/workflows/deploy.sh
+++ b/.github/workflows/deploy.sh
@@ -2,4 +2,4 @@ cp build/fylke.json destinationRepo/
 cp build/fylke.schema.json destinationRepo/
 cp build/kommune.json destinationRepo/
 cp build/kommune.schema.json destinationRepo/
-tar cf artifacts.tar build
+tar czf artifacts.tar -C build .


### PR DESCRIPTION
- Enable gzip compression (tar.gz)
- Avoid extra directory 'build' being included in .tar file