### PR TITLE
Bruk repo navn på releasen for å få unike navn ved nedlasting

### DIFF
--- a/.github/workflows/deploy.sh
+++ b/.github/workflows/deploy.sh
@@ -2,4 +2,4 @@ cp build/fylke.json destinationRepo/
 cp build/fylke.schema.json destinationRepo/
 cp build/kommune.json destinationRepo/
 cp build/kommune.schema.json destinationRepo/
-tar czf artifacts.tar -C build .
+tar czf $(basename $GITHUB_REPOSITORY).tar.gz -C build .

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Create release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "artifacts.tar"
+          artifacts: "${{ $(basename $GITHUB_REPOSITORY) }}.tar.gz"
           tag: v_${{ github.run_number }}
   workflow_dispatch:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Når flere filer lastes ned f.eks. i nin-data-lastejobb så er det en smule ryddigere hvis de har unike navn.